### PR TITLE
Update to use owlapi-3.4.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Maven
 target/
-
+build
 # maven-dependency-plugin
 /*.jar
 
@@ -9,6 +9,9 @@ target/
 .project
 .settings/
 META-INF/
-
+#intellij
+.idea
+*.iml
+*.ipr
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>net.sourceforge.owlapi</groupId>
 			<artifactId>owlapi-distribution</artifactId>
-			<version>3.4.3</version>
+			<version>3.4.10</version>
 		</dependency>
 				
         <dependency>
@@ -112,16 +112,17 @@
 						<Bundle-Vendor>The Protege Development Team</Bundle-Vendor>
 						<Export-Package>org.protege.owlapi.*</Export-Package>
 					</instructions>
-					<executions>
-						<execution>
-							<id>bundle-manifest</id>
-							<phase>install</phase>
-							<goals>    
-								<goal>manifest</goal>
-							</goals>   
-						</execution>
-					</executions>
 				</configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
             </plugin>
 
             <!-- Execution of unit tests generates output for reporting plugin -->


### PR DESCRIPTION
Update to use latest owlapi-3.4.10. 
Needed to avoid pulling grabbing inconsistent  versions into protege desktop build.   

Will cause error in protege-desktop until use of private  methods and fields in that project are changed. 

See  issue 27 in that project - https://github.com/protegeproject/protege/issues/27
