### PR TITLE
Update owlapi version to 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This pull request updates the owlapi dependency to version 3.5.1, and sets the java language level to 1.7 (which is the language level used by owlapi 3.5.*)
